### PR TITLE
support non-SSE environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ DEBUGFLAGS=-g
 
 CXXFLAGS=$(OPTFLAGS) $(DEBUGFLAGS) $(WARNINGS)
 
+HAVE_SSE2=$(shell grep sse2 /proc/cpuinfo)
+ifneq ($(HAVE_SSE2),)
+	CXXFLAGS += -msse2 -DHAVE_SSE2
+endif
+HAVE_SSSE3=$(shell grep ssse3 /proc/cpuinfo)
+ifneq ($(HAVE_SSSE3),)
+	CXXFLAGS += -mssse3 -DHAVE_SSSE3
+endif
+
 PROGS = benchmark zfec test_recovery gen_test_vec
 
 all: fecpp.so pyfecpp.so $(PROGS)
@@ -24,10 +33,10 @@ cpuid.o: cpuid.cpp fecpp.h
 	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
 
 fecpp_sse2.o: fecpp_sse2.cpp fecpp.h
-	$(CXX) $(CXXFLAGS) -msse2 -I. -c $< -o $@
+	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
 
 fecpp_ssse3.o: fecpp_ssse3.cpp fecpp.h
-	$(CXX) $(CXXFLAGS) -mssse3 -I. -c $< -o $@
+	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
 
 test/%.o: test/%.cpp fecpp.h
 	$(CXX) $(CXXFLAGS) -I. -c $< -o $@

--- a/cpuid.cpp
+++ b/cpuid.cpp
@@ -3,8 +3,20 @@
 
 namespace fecpp {
 
-bool has_sse2() { return true; }
+bool has_sse2() {
+#ifdef HAVE_SSE2
+  return true;
+#else
+  return false;
+#endif
+}
 
-bool has_ssse3() { return true; }
+bool has_ssse3() {
+#ifdef HAVE_SSSE3
+  return true;
+#else
+  return false;
+#endif
+}
 
 }

--- a/fecpp.cpp
+++ b/fecpp.cpp
@@ -170,7 +170,6 @@ void addmul(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
       size--;
       }
 
-#if defined(FECPP_IS_X86)
    if(size >= 16 && has_ssse3())
       {
       const size_t consumed = addmul_ssse3(z, x, y, size);
@@ -188,7 +187,6 @@ void addmul(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
       y += consumed;
       size -= consumed;
       }
-#endif
 
    while(size >= 16)
       {

--- a/fecpp.h
+++ b/fecpp.h
@@ -22,10 +22,6 @@ using std::size_t;
 
 using byte = std::uint8_t;
 
-#if defined(__i386__) || defined(__x86_64__)
-  #define FECPP_IS_X86
-#endif
-
 /**
 * Forward error correction code
 */
@@ -67,7 +63,6 @@ class fec_code
       std::vector<uint8_t> enc_matrix;
    };
 
-#if defined(FECPP_IS_X86)
 
 /**
 * CPU runtime detection
@@ -77,8 +72,6 @@ bool has_ssse3();
 
 size_t addmul_sse2(uint8_t z[], const uint8_t x[], uint8_t y, size_t size);
 size_t addmul_ssse3(uint8_t z[], const uint8_t x[], uint8_t y, size_t size);
-
-#endif
 
 }
 

--- a/fecpp_sse2.cpp
+++ b/fecpp_sse2.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "fecpp.h"
+#ifdef HAVE_SSE2
 #include <emmintrin.h>
+#endif
 
 namespace fecpp {
-
+#ifdef HAVE_SSE2
 size_t addmul_sse2(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
    {
    const __m128i polynomial = _mm_set1_epi8(0x1D);
@@ -98,5 +100,10 @@ size_t addmul_sse2(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
 
    return consumed;
    }
-
+#else
+size_t addmul_sse2(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
+{
+  throw std::runtime_error("SSE2 is not supported in the hardware");
+}
+#endif
 }

--- a/fecpp_ssse3.cpp
+++ b/fecpp_ssse3.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "fecpp.h"
+#ifdef HAVE_SSSE3
 #include <tmmintrin.h>
+#endif
 
 namespace fecpp {
-
+#ifdef HAVE_SSSE3
 namespace {
 
 /*
@@ -569,6 +571,11 @@ size_t addmul_ssse3(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
 
    return consumed;
    }
-
+#else
+size_t addmul_ssse3(uint8_t z[], const uint8_t x[], uint8_t y, size_t size)
+{
+  throw std::runtime_error("SSSE3 is not supported in the hardware");
+}
+#endif
 }
 


### PR DESCRIPTION
Currently this library cannot be built on non SSE environment.
I added `if` condition for SSE2/non-SSE2 and SSSE3/non-SSSE3 environment.